### PR TITLE
fix incorrect tempalting. hack letsencrypt .well-known override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
-.vagrant/
-
 # terraform stuff
 .terraform
 terraform.tfstate
 **/terraform.tfvars
 **/inventory.remote
-
-# generated ansible inventory
-*.ansible
+ansible/keys

--- a/ansible/roles/ci-properties/defaults/main.yaml
+++ b/ansible/roles/ci-properties/defaults/main.yaml
@@ -28,7 +28,7 @@ github_client_id: "{{ lookup('env','GITHUB_CLIENT_ID') }}"
 github_client_key: "{{ lookup('env','GITHUB_CLIENT_KEY') }}"
 github_token: "{{ lookup('env','GITHUB_ACCESS_TOKEN') }}"
 github_username: "{{ lookup('env','GITHUB_USERNAME') }}"
-jenkins_ssh_key_path: "{{ lookup('env','HOME')/{{ ci_hostname }}"
+jenkins_ssh_key_path: "{{playbook_dir}}/keys/{{ ci_hostname }}"
 jenkins_ssh_key: "{{ jenkins_ssh_key_path }}/id_rsa.pub"
 nginx_container_name: nginx
 nginx_container_path: "{{ ansible_env.HOME }}/config/nginx"

--- a/config/nginx/conf/nginx.tmpl
+++ b/config/nginx/conf/nginx.tmpl
@@ -122,6 +122,12 @@ server {
     auth_basic_user_file  {{ (printf "/etc/nginx/htpasswd/%s" $host) }};
     {{ end }}
   }
+
+  location /.well-known/ {
+    auth_basic off;
+    root /usr/share/nginx/html;
+    try_files $uri =404;
+  }
 }
 {{ else }}
 
@@ -147,6 +153,12 @@ server {
     auth_basic  "Restricted {{ $host }}";
     auth_basic_user_file  {{ (printf "/etc/nginx/htpasswd/%s" $host) }};
     {{ end }}
+  }
+
+  location /.well-known/ {
+    auth_basic off;
+    root /usr/share/nginx/html;
+    try_files $uri =404;
   }
 }
 


### PR DESCRIPTION
by default letsencrypt container drops a location override into /etc/nginx/vhost.d 

```
# Start of configuration add by letsencrypt container
location /.well-known/ {
    auth_basic off;
    root /usr/share/nginx/html;
    try_files $uri =404;
}
## End of configuration add by letsencrypt container
```

for whatever reason nginx now ignores the override and continues to happily reverse-proxy onto to jenkins. Let's add the override directly into the nginx config template.